### PR TITLE
Remove section about affected App Center service in feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,9 +7,6 @@ assignees: ''
 
 ---
 
-**What App Center service does this feature apply to?**
-What specific area is affected by the solution.
-
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 


### PR DESCRIPTION
The question seemed to be causing confusion or be largely ignored. Removed it for now.
If the affected area is ever unclear, we can always ask. Otherwise, it is usually clear from the context of the request.