### PR TITLE
Build 64-bit android binary

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -17,7 +17,7 @@ flutter doctor
 
 echo "Installed flutter to `pwd`/flutter"
 
-flutter build apk --release
+flutter build apk --target-platform android-arm64 --release
 
 #copy the APK where AppCenter will find it
 mkdir -p android/app/build/outputs/apk/; mv build/app/outputs/apk/release/app-release.apk $_


### PR DESCRIPTION
> Starting August 1, 2019, your apps published on Google Play will need to support 64-bit architectures: 

https://developer.android.com/distribute/best-practices/develop/64-bit