### PR TITLE
Remove target-platform flag

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -17,7 +17,7 @@ flutter doctor
 
 echo "Installed flutter to `pwd`/flutter"
 
-flutter build apk --target-platform android-arm64 --release
+flutter build apk --release
 
 #copy the APK where AppCenter will find it
 mkdir -p android/app/build/outputs/apk/; mv build/app/outputs/apk/release/app-release.apk $_


### PR DESCRIPTION
I screwed up #693 -- the latest release of Flutter stable will build both 64- and 32-bit ARM by default. 

With the `--target-platform android-arm64` flag, `arm64-v8a` is built.

With no flag, both `armeabi-v7a` and `arm64-v8a` are built into a single APK. (Note that AppCenter doesn't yet support uploading app bundles #194)

See https://flutter.dev/docs/deployment/android#build-an-apk for more details.

This reverts commit 4651904eb9dc4b4bd89e9be5b312578edfb6e9c9, reversing changes made to 22121d8b8e94e70641d36c2c703f32640ac7d0f3.