### PR TITLE
Create issue template config.yml to limit blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bugs and support requests
+    url: https://appcenter.ms
+    about: Please report bugs and support requests using the blue bubble in the lower-right corner of the App Center UI.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Bugs and support requests
     url: https://appcenter.ms
-    about: Please report bugs and support requests using the blue bubble in the lower-right corner of the App Center UI.
+    about: Please report bugs and support requests using the App Center in-product support experience.


### PR DESCRIPTION
Leverage the new issue template configuration options to 1) remove the option to create an empty issue and 2) encourage navigating to appcenter.ms to file bugs and open support requests.

This should help avoid the number of "bug" and question issues filed in this repository.

https://github.blog/changelog/2019-10-28-new-issue-template-configuration-options/

Will make our /issues/new/choose page look more like this:
![image](https://user-images.githubusercontent.com/19493383/67722242-d3c72d80-f995-11e9-85b2-ace3c4edb724.png)
