### PR TITLE
App bundle build output change

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -27,4 +27,4 @@ flutter build apk --release
 mkdir -p android/app/build/outputs/apk/; mv build/app/outputs/apk/release/app-release.apk $_
 
 # copy the AAB where AppCenter will find it
-#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app.aab $_
+#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app-release.aab $_


### PR DESCRIPTION
Received this error during the app's deployment build in Appcenter.
```
✓ Built build/app/outputs/bundle/release/app-release.aab (22.9MB).
+ mkdir -p android/app/build/outputs/bundle/
+ mv build/app/outputs/bundle/release/app.aab android/app/build/outputs/bundle/
mv: rename build/app/outputs/bundle/release/app.aab to android/app/build/outputs/bundle/app.aab: No such file or directory
##[error]/bin/bash failed with return code: 1
##[error]Bash failed with error: /bin/bash failed with return code: 1
```

- I modified the build output to `build/app/outputs/bundle/release/app-release.aab` from `build/app/outputs/bundle/release/app.aab` and it works.