### PR TITLE
Update .aab path

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -27,4 +27,4 @@ flutter build apk --release
 mkdir -p android/app/build/outputs/apk/; mv build/app/outputs/apk/release/app-release.apk $_
 
 # copy the AAB where AppCenter will find it
-#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app.aab $_
+#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app-release.aab $_


### PR DESCRIPTION
Flutter appbundle generates `app-release.aab` instead of `app.aab` which causes current script to fail.