### PR TITLE
Gradle does not have execution permission

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -9,6 +9,7 @@ set -e
 set -x
 
 cd ..
+chmod a+rx android/gradlew
 git clone -b beta https://github.com/flutter/flutter.git
 export PATH=`pwd`/flutter/bin:$PATH
 


### PR DESCRIPTION
Get error message as below:
[!] Gradle does not have execution permission.
    You should change the ownership of the project directory to your ***, or move the project to a directory with execute permissions.
Gradle task assembleAlphaRelease failed with exit code 1

so I add chmod a+rx android/gradlew here.