### PR TITLE
Add forms gallery submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "sample-apps/xamarin/appcenter-Xamarin.UITest-Demo"]
 	path = sample-apps/xamarin/appcenter-Xamarin.UITest-Demo
 	url = https://github.com/microsoft/appcenter-Xamarin.UITest-Demo
+[submodule "sample-apps/xamarin/Xamarin.Forms-Gallery"]
+	path = sample-apps/xamarin/Xamarin.Forms-Gallery
+	url = https://github.com/microsoft/appcenter-Xamarin.Forms-Gallery-Demo

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "sample-apps/xamarin/appcenter-Xamarin.UITest-Demo"]
 	path = sample-apps/xamarin/appcenter-Xamarin.UITest-Demo
 	url = https://github.com/microsoft/appcenter-Xamarin.UITest-Demo
+[submodule "sample-apps/xamarin/appcenter-Xamarin.Forms-Gallery-Demo"]
+	path = sample-apps/xamarin/appcenter-Xamarin.Forms-Gallery-Demo
+	url = https://github.com/microsoft/appcenter-Xamarin.Forms-Gallery-Demo

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "sample-apps/xamarin/appcenter-Xamarin.UITest-Demo"]
 	path = sample-apps/xamarin/appcenter-Xamarin.UITest-Demo
 	url = https://github.com/microsoft/appcenter-Xamarin.UITest-Demo
-[submodule "sample-apps/xamarin/appcenter-Xamarin.Forms-Gallery-Demo"]
-	path = sample-apps/xamarin/appcenter-Xamarin.Forms-Gallery-Demo
-	url = https://github.com/microsoft/appcenter-Xamarin.Forms-Gallery-Demo


### PR DESCRIPTION
Depends on https://github.com/microsoft/appcenter-Xamarin.Forms-Gallery-Demo/pull/1

Created submodule reference using this command:
> git submodule add https://github.com/microsoft/appcenter-Xamarin.Forms-Gallery-Demo Xamarin.Forms-Gallery

In this folder:
> [path to local repo]/appcenter/tree/master/sample-apps/xamarin