### PR TITLE
Error fix while generating aab file

### DIFF
--- a/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
+++ b/sample-build-scripts/flutter/android-build/appcenter-post-clone.sh
@@ -27,4 +27,4 @@ flutter build apk --release
 mkdir -p android/app/build/outputs/apk/; mv build/app/outputs/apk/release/app-release.apk $_
 
 # copy the AAB where AppCenter will find it
-#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app.aab $_
+#mkdir -p android/app/build/outputs/bundle/; mv build/app/outputs/bundle/release/app-release.aab $_


### PR DESCRIPTION
https://github.com/microsoft/appcenter/pull/1629

My fix solves this issue, because gradle generates app-release.aab but during the build appcenter tries to find app.aab file which leads to error "No such file or directory"