### PR TITLE
Note: do not ignore Gradle wrapper files

### DIFF
--- a/sample-build-scripts/flutter/readme.md
+++ b/sample-build-scripts/flutter/readme.md
@@ -1,4 +1,6 @@
 # Flutter Build Scripts for App Center
 Currently, Flutter is **not** supported by App Center. But these build scripts allow you to add custom functionality beyond the normal scope of that support. They are provided as-is and may be sufficient for your use case; but you might also encounter limitations that aren't immediately addressable by the App Center team. 
 
+> App Center tracks the project by searching the gradle(and gradlew) directory files on the Android project, please do not ignore those files(on the project .gitignore) as App Center Build service will not find it.
+
 You can vote for Flutter support with a thumbs-up here: https://github.com/microsoft/appcenter/issues/67. It also has some discussion of common issues and possible workarounds users have found. 


### PR DESCRIPTION
App Center Build Service does not find the Android project when you ignore the Gradle wrapper files, add a quick notice to not ignore those files on the docs, this is also discussed on MicrosoftDocs/appcenter-docs#1327